### PR TITLE
Fix *random-state* type error under SBCL 1.2.4

### DIFF
--- a/Code/defs.lisp
+++ b/Code/defs.lisp
@@ -14,7 +14,7 @@
 (defpackage :fset
   (:use :cl :gmap :new-let :lexical-contexts)
   (:shadowing-import-from :new-let #:let #:cond)
-  (:shadowing-import-from :mt19937 #:make-random-state #:random)
+  (:shadowing-import-from :mt19937 #:make-random-state #:random #:*random-state*)
   ;; For each of these shadowed symbols, using packages must either shadowing-
   ;; import it or shadowing-import the original Lisp symbol.
   (:shadow ;; Shadowed type/constructor names


### PR DESCRIPTION
mt19937 reimplements CL:RANDOM and friends.  Function MT19937:RANDOM
uses MT19937:_RANDOM-STATE_ so it seems that symbol should be imported
into package :fset so the _unqualified_ reference to it in
RUN-TEST-SUITE refers to the correct symbol.
