### PR TITLE
Return a second value from lookup on CL sequences

### DIFF
--- a/Code/fset.lisp
+++ b/Code/fset.lisp
@@ -2958,7 +2958,7 @@ not symbols."))
   (length s))
 
 (defmethod lookup ((s sequence) (idx integer))
-  (elt s idx))
+  (values (elt s idx) t))
 
 
 ;;; ================================================================================


### PR DESCRIPTION
This makes it easier to write code that works with both CL sequences
and FSet seqs.

Fixes #23.