### PR TITLE
Fix increment-atomic-series for non-SBCL or Allegro

### DIFF
--- a/Code/port.lisp
+++ b/Code/port.lisp
@@ -288,7 +288,7 @@
   `(1- (excl:incf-atomic (car ,name)))
   #-(or (and sbcl 64-bit) (and allegro smp-macros))
   `(with-lock ((cdr ,name))
-     (1- (incf ,(car name)))))
+     (1- (incf (car ,name)))))
 
 
 ;;; ----------------


### PR DESCRIPTION
The macro definition of increment-atomic-series has a misplaced comma preventing FSet from being loaded on CCL (or any Lisp that isn't SBCL or Allegro).