### PR TITLE
Use atomic increments on CCL

### DIFF
--- a/Code/port.lisp
+++ b/Code/port.lisp
@@ -286,7 +286,9 @@
   `(sb-ext:atomic-incf ,name) ; (postincrement)
   #+(and allegro smp-macros)
   `(1- (excl:incf-atomic (car ,name)))
-  #-(or (and sbcl 64-bit) (and allegro smp-macros))
+  #+ccl
+  `(1- (ccl::atomic-incf (car ,name)))
+  #-(or (and sbcl 64-bit) (and allegro smp-macros) ccl)
   `(with-lock ((cdr ,name))
      (1- (incf (car ,name)))))
 


### PR DESCRIPTION
This changes increment-atomic-series to use `ccl::atomic-incf` on CCL to avoid taking a lock.

LIght testing suggests this yields a 15-20% performance improvement.