### PR TITLE
Improve support for CL functions and sequences

### DIFF
--- a/Code/order.lisp
+++ b/Code/order.lisp
@@ -373,6 +373,24 @@ and thus of types named by those symbols.")
 			((eq cmp ':unequal)
 			 (setq unequal? t))))))))))))
 
+;; Fallback for generic sequences
+(defmethod compare ((a sequence) (b sequence))
+  (if (eq a b) ':equal
+    (if (not (eq (class-of a) (class-of b)))
+	  ;; Since their types don't overlap, fallback to another handler
+	  (call-next-method)
+	(let ((dims-cmp (compare (length a) (length b))))
+	  (if (member dims-cmp '(:less :greater))
+	      dims-cmp
+	    (let ((unequal? nil)
+		  (size (length a)))
+	      (dotimes (i size (if unequal? ':unequal ':equal))
+		(let ((cmp (compare (elt a i) (elt b i))))
+		  (cond ((member cmp '(:less :greater))
+			 (return cmp))
+			((eq cmp ':unequal)
+			 (setq unequal? t)))))))))))
+
 
 ;;; ================================================================================
 ;;; Lexicographic comparison of sequences


### PR DESCRIPTION
What it says on the tin. 
- Extends multiple FSet functions to work out of the box with CL vectors and sequences (including sequences defined via the `extensible-sequences` protocol)
- Extends support for ordinary CL functions (modeling them as a mapping from input to output).

None of the definitions here should interfere with user-defined methods on `sequence` / `function` / their subtypes.