### PR TITLE
Iterate integration fixes and improvements

### DIFF
--- a/Code/iterate-tests.lisp
+++ b/Code/iterate-tests.lisp
@@ -28,6 +28,8 @@
 
     (test (equal? (iter (for x :in-set (set 1 3 7)) (collect x))
 		  '(1 3 7)))
+    (test (equal? (iter (for x :in-iterator (set 1 3 7)) (collect x))
+		  '(1 3 7)))
     (test (equal? (iter (for x :in-bag (bag 1 3 3 7)) (collect x))
 		  '(1 3 3 7)))
     (test (equal? (iter (for (x n) :in-bag (bag 1 3 3 7)) (collect (cons x n)))

--- a/Code/iterate-tests.lisp
+++ b/Code/iterate-tests.lisp
@@ -20,6 +20,12 @@
 		      (collect x)))
 		  '(3 4)))
 
+    (test (equal? (iter (with s = (empty-set))
+                        (for x in '(3 4))
+                        (setf s (with s x))
+                        (finally (return s)))
+		  (set 3 4)))
+
     (test (equal? (iter (for x :in-set (set 1 3 7)) (collect x))
 		  '(1 3 7)))
     (test (equal? (iter (for x :in-bag (bag 1 3 3 7)) (collect x))

--- a/Code/iterate-tests.lisp
+++ b/Code/iterate-tests.lisp
@@ -76,13 +76,13 @@
     (test (equal? (iter (for x in '(q w e r t y u i o p)) (collect-seq x))
 		  (convert 'seq '(q w e r t y u i o p))))
 
-    (test (equal? (iter (for (k v) in '((a 3) (b 7) (c 4))) (collect-map k -> v))
+    (test (equal? (iter (for (k v) in '((a 3) (b 7) (c 4))) (collect-map k v))
 		  (map ('a 3) ('b 7) ('c 4))))
     (test (equal? (iter (for (k v) in '((a 3) (b 7) (c 4)))
-		    (collect-map k -> v :initial-value (wb-custom-map 'fset::erapmoc nil)))
+		    (collect-map k v :initial-value (wb-custom-map 'fset::erapmoc nil)))
 		  (wb-custom-map 'fset::erapmoc nil ('a 3) ('b 7) ('c 4))))
     (test (equal? (iter (for (k v) in '((a 3) (b 7) (c 4) (b 13) (d 22) (a 12) (a 17)))
-		    (collect-map-to-sets k -> v))
+		    (collect-map-to-sets k v))
 		  (map ('a (set 3 12 17)) ('b (set 7 13)) ('c (set 4)) ('d (set 22)) :default (set))))
 
     (test (equal? (iter (for s in (list (set 1 2) (set 2 5))) (unioning s))

--- a/Code/iterate.lisp
+++ b/Code/iterate.lisp
@@ -40,6 +40,15 @@
     (setq *loop-end-used?* t)
     (return-driver-code :next (list test setqs) :variable var)))
 
+(defclause-driver (for var in-iterator x)
+  "Elements of any FSet iterator."
+  (top-level-check)
+  (let ((iter-var (make-var-and-binding 'iter `(iterator ,x)))
+	((setqs (do-dsetq var `(funcall ,iter-var ':get)))
+	 (test `(when (funcall ,iter-var ':done?) (go ,*loop-end*)))))
+    (setq *loop-end-used?* t)
+    (return-driver-code :next (list test setqs) :variable var)))
+
 (defclause-driver (for var-or-var*count in-bag bag)
   "Elements or pairs of a bag.  If `var-or-var*count' is a symbol, it
 will be bound to successive values from the bag, with repetitions of

--- a/Code/iterate.lisp
+++ b/Code/iterate.lisp
@@ -164,18 +164,28 @@ Use `initial-value' to construct a different kind of bag."
     (make-accum-var-binding var-spec init-val nil :type nil)
     (return-code :body `((setq ,var ,op-expr)))))
 
+(defmacro collect-map (key-expr val-expr &rest args)
+  "This macro exists for Iterate's code walker to expand it into an
+actual clause."
+  `(%collect-map ,key-expr -> ,val-expr ,@args))
+
 ;;; The arrow (or some keyword, anyway) is required by Iterate.  Be glad I didn't use Unicode `→' :-)
-(defclause (collect-map key-expr -> val-expr &optional initial-value init-val into var-spec)
+(defclause (%collect-map key-expr -> val-expr &optional initial-value init-val into var-spec)
   "Collects key/value pairs into a map, by default a `wb-map' ordered by
 `compare'.  Use `initial-value' to construct a different kind of map."
   (local-binding-check init-val)
   (let ((var-spec (or var-spec *result-var*))
 	((var (extract-var var-spec))
-	 ((op-expr `(with ,var ,(walk-expr key-expr) ,(walk-expr val-expr))))))
+	  ((op-expr `(with ,var ,(walk-expr key-expr) ,(walk-expr val-expr))))))
     (make-accum-var-binding var-spec (or init-val '(wb-map)) nil :type nil)
     (return-code :body `((setq ,var ,op-expr)))))
 
-(defclause (collect-map-to-sets key-expr -> val-expr &optional initial-value init-val into var-spec)
+(defmacro collect-map-to-sets (key-expr val-expr &rest args)
+  "This macro exists for Iterate's code walker to expand it into an
+actual clause."
+  `(%collect-map-to-sets ,key-expr -> ,val-expr ,@args))
+
+(defclause (%collect-map-to-sets key-expr -> val-expr &optional initial-value init-val into var-spec)
   "Collects key/value pairs into a map, collecting values for each key into a
 set.  By default, the result a `wb-map' ordered by `compare', and the value
 sets are `wb-sets' ordered by `compare'.  Use `initial-value' to construct a

--- a/fset.asd
+++ b/fset.asd
@@ -63,6 +63,7 @@ See: https://gitlab.common-lisp.net/fset/fset/-/wikis/home
   :source-control "https://github.com/slburson/fset"
   :license "BSD-2-Clause"
   :depends-on ("fset" "iterate")
+  :in-order-to ((test-op (load-op "fset/iterate/test")))
   :components ((:module "Code"
 		:serial t
 		:components ((:file "iterate-defs")
@@ -71,11 +72,7 @@ See: https://gitlab.common-lisp.net/fset/fset/-/wikis/home
 (defsystem :FSet/Iterate/test
   :description "Test system for FSet/Iterate"
   :depends-on (:fset/iterate)
+  :perform (test-op (o c) (symbol-call :fset/iterate/test :test-fset/iterate))
   :components ((:module "Code"
 		:serial t
 		:components ((:file "iterate-tests")))))
-
-(defmethod perform ((o test-op) (c (eql (find-system :fset/iterate))))
-  (load-system :fset/iterate/test)
-  (funcall (intern (symbol-name '#:test-fset/iterate) :fset/iterate)))
-


### PR DESCRIPTION
We use FSet with iterate extensively and had a lot of code to test the new integration against.

This PR fixes two issues:
- The function in `test-op` for `fset/iterate` was incorrect.
- The workaround for making `fset:with` usable for bindings did not work as intended. It worked in the example in the test suite only because the initialization code inside a `with` binding is not walked by the Iterate code walker. However, `with` in walked code was still always being treated as if it were a binding clause that had to have keywords in the right place. (You can try the example I added to confirm.) I did find another way to get the same result, though, by treating `fset:with` as a special form, and that appears to work as intended, although there is still a certain brittleness since the list of special forms is a `defparameter` and would be reset if Iterate were reloaded independently.

The PR also makes two enhancements:
- Adding an `in-iterator` driver. This is nice to have as a universal bridge between anything that uses the FSet iterator protocol and Iterate. Currently it just shares its implementation with `in-set`. 
- It adds "facade" macros to `collect-map` and `collect-map-to-sets`, to avoid needing `->` sigils to use them. The macros are expanded by Iterate's code walker into the actual clause syntax. I actually wrote something about this years ago if it makes the approach clearer: https://web.archive.org/web/20230224093450/https://etc.ruricolist.com/2019/12/16/the-iterate-clause-trick/.