### PR TITLE
Add CSS theme: Ember

### DIFF
--- a/Doc/Modern-CL/fset.css
+++ b/Doc/Modern-CL/fset.css
@@ -54,6 +54,19 @@
     color-scheme:  dark;
 }
 
+:root[data-theme="ember"] {
+    --bg:          #1c1b19;
+    --fg:          #d8d0c0;
+    --link:        #e08060;
+    --link-visited:#8a9868;
+    --nav-bg:      #2e2d2a;
+    --nav-border:  #c09058;
+    --code-bg:     #222120;
+    --code-border: #7890a0;
+    --def-bg:      #252422;
+    color-scheme:  dark;
+}
+
 /* ── Base ────────────────────────────────────────────────────────────────── */
 
 body {

--- a/Doc/Modern-CL/theme.js
+++ b/Doc/Modern-CL/theme.js
@@ -1,8 +1,8 @@
 /* FSet book theme switcher */
 
 (function () {
-    var THEMES = ['bright', 'light', 'dark', 'hc'];
-    var LABELS = { bright: 'Bright', light: 'Light', dark: 'Dark', hc: 'High Contrast' };
+    var THEMES = ['bright', 'light', 'dark', 'hc', 'ember'];
+    var LABELS = { bright: 'Bright', light: 'Light', dark: 'Dark', hc: 'High Contrast', ember: 'Ember' };
     var STORAGE_KEY = 'modern-cl-theme';
 
     // Map our logical names to data-theme attribute values (light = default, no attribute).


### PR DESCRIPTION
## I did this on a whim...

...and I think it turned out alright.  I figured I might as well donate it.

The colors are based on the ember theme.
https://embertheme.com/
https://github.com/ember-theme/emacs

Unfortunately, I couldn't build the HTML locally using the provided Makefile.  It spit out pages of errors, but there were only two kinds.

1. `unknown command 'link' (possibly involving @href)` (99+% of the errors)
2. `@include: could not find Afterword.texi`

With that said, I was able to apply the CSS on the [live document](https://fset.common-lisp.dev/Modern-CL/Top_html/index.html) using the Stylus browser extension, and it looks like this.

<img width="975" height="1963" alt="fset-ember" src="https://github.com/user-attachments/assets/f52f595e-dab7-40a7-961e-bd8128ec49c3" />
