### PR TITLE
test: fix testing filenames in asd

### DIFF
--- a/fset.asd
+++ b/fset.asd
@@ -54,7 +54,9 @@ See: https://gitlab.common-lisp.net/fset/fset/-/wikis/home
   :perform (test-op (o c) (symbol-call :fset :run-test-suite 200))
   :components
   ((:module "Code"
-	    :components ((:file "testing")))))
+	    :components
+	    ((:file "testing-0")
+	     (:file "testing-1")))))
 
 (defsystem :FSet/Iterate
   :description "FSet definitions for the Iterate macro."


### PR DESCRIPTION
Regression introduced in 984cca91523a7eb0b4578d0ee3e3b0cd252671ee