### PR TITLE
Add CL-Amiga (clamiga) port

### DIFF
--- a/Code/port.lisp
+++ b/Code/port.lisp
@@ -185,6 +185,19 @@
   (defmacro write-memory-barrier ()
     'nil))
 
+#+cl-amiga
+(progn
+  (defun make-lock (&optional name)
+    (declare (ignore name))
+    nil)
+  (defmacro with-lock ((lock &key (wait? t)) &body body)
+    (declare (ignore lock wait?))
+    `(progn . ,body))
+  (defmacro read-memory-barrier ()
+    'nil)
+  (defmacro write-memory-barrier ()
+    'nil))
+
 
 #+(and ecl (not threads))
 (progn
@@ -393,6 +406,10 @@
   (code-char (+ code (ash bits 8))))
 
 #+ecl
+(defun make-char (code bits)
+  (code-char (+ code (ash bits 8))))
+
+#+cl-amiga
 (defun make-char (code bits)
   (code-char (+ code (ash bits 8))))
 


### PR DESCRIPTION
Add #+cl-amiga branches in Code/port.lisp: lock/memory-barrier stubs (threading maps onto CL-Amiga's MP package) and a make-char helper. FSet's own test suite passes 17/17 on CL-Amiga (requires misc-extensions >= 4.2.4).